### PR TITLE
README.md: Re-generate

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 *display relative line number in emacs.*
 
 ---
-[![License GPL3](https://img.shields.io/badge/license-GPL_3-green.svg?dummy)](http://www.gnu.org/licenses/gpl-3.0.html)
+[![License GPLv2](https://img.shields.io/badge/license-GPL_v2-green.svg)](http://www.gnu.org/licenses/gpl-2.0.html)
 [![MELPA](http://melpa.org/packages/linum-relative-badge.svg)](http://melpa.org/#/linum-relative)
 [![MELPA Stable](http://stable.melpa.org/packages/linum-relative-badge.svg)](http://stable.melpa.org/#/linum-relative)
 

--- a/linum-relative.el
+++ b/linum-relative.el
@@ -24,7 +24,6 @@
 ;; Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 ;;; Commentary:
-;; [![License GPL3](https://img.shields.io/badge/license-GPL_3-green.svg?dummy)](http://www.gnu.org/licenses/gpl-3.0.html)
 ;; [![MELPA](http://melpa.org/packages/linum-relative-badge.svg)](http://melpa.org/#/linum-relative)
 ;; [![MELPA Stable](http://stable.melpa.org/packages/linum-relative-badge.svg)](http://stable.melpa.org/#/linum-relative)
 


### PR DESCRIPTION
`make-readme-markdown` has recently gained the ability to add a license badge to your `README.md` if a license can be detected.  Here's how it looks.

(Note that the `.el` file actually has the GPLv2 license, so that's why the badge changed.)